### PR TITLE
Update VMWare Fusion to use brew-cask

### DIFF
--- a/recipes/vmware_fusion.rb
+++ b/recipes/vmware_fusion.rb
@@ -1,6 +1,2 @@
-dmg_package "VMWare Fusion" do
-  source "http://download2us.softpedia.com/dl/a5bdb8f0e2faf4dcea62bf272213d56c/513376a7/400024122/mac/System-Utilities/VMware-Fusion-5.0.2-900491-light.dmg"
-  action :install
-  type "app"
-  package_id "com.vmware.tools.application"
-end
+include_recipe "applications::homebrewcask"
+applications_cask "vmware-fusion"


### PR DESCRIPTION
VMWare Fusion was recently added to homebrew-cask and is at version 5.0.3
