### PR TITLE
Change recipes to follow homebrew-cask

### DIFF
--- a/recipes/chicken.rb
+++ b/recipes/chicken.rb
@@ -1,5 +1,2 @@
-dmg_package "Chicken" do
-    source "http://garr.dl.sourceforge.net/project/chicken/Chicken-2.2b2.dmg"
-    action :install
-    only_if { platform?('mac_os_x') }
-end
+include_recipe "applications::homebrewcask"
+applications_cask "chicken"

--- a/recipes/crashplan.rb
+++ b/recipes/crashplan.rb
@@ -1,7 +1,2 @@
-dmg_package "Install CrashPlan" do
-  source "http://download.crashplan.com/installs/mac/install/CrashPlan/CrashPlan_3.5.2_Mac.dmg"
-  volumes_dir "CrashPlan"
-  action :install
-  type "pkg"
-  package_id "com.crashplan.app.pkg"
-end
+include_recipe "applications::homebrewcask"
+applications_cask "crashplan"

--- a/recipes/cyberduck.rb
+++ b/recipes/cyberduck.rb
@@ -1,3 +1,2 @@
-applications_package "Cyberduck" do
-  source  "http://cyberduck.ch/Cyberduck-4.2.1.zip"
-end
+include_recipe "applications::homebrewcask"
+applications_cask "cyberduck"

--- a/recipes/diffmerge.rb
+++ b/recipes/diffmerge.rb
@@ -1,5 +1,2 @@
-dmg_package 'DiffMerge' do
-    source 'http://download-us.sourcegear.com/DiffMerge/3.3.2/DiffMerge.3.3.2.1139.dmg'
-    action :install
-    volumes_dir "DiffMerge 3.3.2.1139"
-end
+include_recipe "applications::homebrewcask"
+applications_cask "diffmerge"

--- a/recipes/flash.rb
+++ b/recipes/flash.rb
@@ -1,22 +1,2 @@
-remote_file "#{Chef::Config[:file_cache_path]}/install_flash_player_osx.dmg" do
-    source "http://fpdownload.macromedia.com/get/flashplayer/pdc/11.8.800.168/install_flash_player_osx.dmg"
-    owner node['current_user']
-    not_if "pkgutil --packages | grep Flash"
-end
-
-execute "attach install_flash_player_osx.dmg" do
-    command "hdiutil attach '#{Chef::Config[:file_cache_path]}/install_flash_player_osx.dmg'"
-    user node['current_user']
-    not_if "pkgutil --packages | grep Flash"
-end
-
-execute "install Flash" do
-    command "installer -pkg \"/Volumes/Flash Player/Install Adobe Flash Player.app/Contents/Resources/Adobe Flash Player.pkg\" -target / -lang en"
-    not_if "pkgutil --packages | grep Flash"
-end
-
-execute "detach install_flash_player_osx.dmg" do
-    command "hdiutil detach \"/Volumes/Flash Player\""
-    user node['current_user']
-    only_if "mount | grep -q 'Flash Player'"
-end
+include_recipe "applications::homebrewcask"
+applications_cask "flash"

--- a/recipes/flux.rb
+++ b/recipes/flux.rb
@@ -1,3 +1,2 @@
-applications_package "Flux" do
-  source  "https://justgetflux.com/mac/Flux.zip"
-end
+include_recipe "applications::homebrewcask"
+applications_cask "f-lux"

--- a/recipes/handbrake.rb
+++ b/recipes/handbrake.rb
@@ -1,6 +1,2 @@
-dmg_package "HandBrake" do
-    source "http://downloads.sourceforge.net/project/handbrake/0.9.9/HandBrake-0.9.9-MacOSX.6_GUI_x86_64.dmg"
-    action :install
-    volumes_dir "HandBrake-0.9.9-MacOSX.6_GUI_x86_64"
-    only_if { platform?('mac_os_x') }
-end
+include_recipe "applications::homebrewcask"
+applications_cask "handbrake"

--- a/recipes/hostbuddy.rb
+++ b/recipes/hostbuddy.rb
@@ -1,3 +1,2 @@
-applications_package "Hostbuddy" do
-  source  "http://dl.clickontyler.com/hostbuddy/hostbuddy_1.0.2.zip"
-end
+include_recipe "applications::homebrewcask"
+applications_cask "hostbuddy"

--- a/recipes/imagealpha.rb
+++ b/recipes/imagealpha.rb
@@ -1,24 +1,2 @@
-unless File.exists?("/Applications/ImageAlpha.app")
-
-  remote_file "#{Chef::Config[:file_cache_path]}/ImageAlpha1.2.5.1.tar.bz2" do
-    source "http://pngmini.com/ImageAlpha1.2.5.1.tar.bz2"
-    owner node['current_user']
-  end
-
-  execute "unzip ImageAlpha" do
-    command "tar -xf #{Chef::Config[:file_cache_path]}/ImageAlpha1.2.5.1.tar.bz2 -C #{Chef::Config[:file_cache_path]}/"
-    user node['current_user']
-  end
-
-  execute "copy ImageAlpha to /Applications" do
-    command "mv #{Chef::Config[:file_cache_path]}/ImageAlpha.app #{Regexp.escape("/Applications/ImageAlpha.app")}"
-    user node['current_user']
-  end
-
-  ruby_block "test to see if ImageAlpha.app was installed" do
-    block do
-      raise "ImageAlpha.app was not installed" unless File.exists?("/Applications/ImageAlpha.app")
-    end
-  end
-
-end
+include_recipe "applications::homebrewcask"
+applications_cask "imagealpha"

--- a/recipes/imageoptim.rb
+++ b/recipes/imageoptim.rb
@@ -1,24 +1,2 @@
-unless File.exists?("/Applications/Imageoptim.app")
-
-  remote_file "#{Chef::Config[:file_cache_path]}/ImageOptim.tbz2" do
-    source "http://imageoptim.com/ImageOptim.tbz2"
-    owner node['current_user']
-  end
-
-  execute "unzip ImageOptim" do
-    command "tar -xf #{Chef::Config[:file_cache_path]}/ImageOptim.tbz2 -C #{Chef::Config[:file_cache_path]}/"
-    user node['current_user']
-  end
-
-  execute "copy ImageOptim to /Applications" do
-    command "mv #{Chef::Config[:file_cache_path]}/ImageOptim.app #{Regexp.escape("/Applications/ImageOptim.app")}"
-    user node['current_user']
-  end
-
-  ruby_block "test to see if ImageOptim.app was installed" do
-    block do
-      raise "ImageOptim.app was not installed" unless File.exists?("/Applications/ImageOptim.app")
-    end
-  end
-
-end
+include_recipe "applications::homebrewcask"
+applications_cask "imageoptim"

--- a/recipes/keyboardcleantool.rb
+++ b/recipes/keyboardcleantool.rb
@@ -1,3 +1,2 @@
-applications_package "KeyboardCleanTool" do
-  source  "http://bettertouchtool.net/KeyboardCleanTool.zip"
-end
+include_recipe "applications::homebrewcask"
+applications_cask "keyboard-clean-tool"

--- a/recipes/lastpass.rb
+++ b/recipes/lastpass.rb
@@ -1,7 +1,2 @@
-dmg_package "lpmacosx" do
-  source "https://download.lastpass.com/lpmacosx.dmg"
-  volumes_dir "LastPass for Mac OS X"
-  action :install
-  type "pkg"
-  package_id "com.lastpass.lpmacosx"
-end
+include_recipe "applications::homebrewcask"
+applications_cask "lastpass-universal"

--- a/recipes/mou.rb
+++ b/recipes/mou.rb
@@ -1,3 +1,2 @@
-applications_package "Mou" do
-  source  "http://mouapp.com/download/Mou.zip"
-end
+include_recipe "applications::homebrewcask"
+applications_cask "mou"

--- a/recipes/omnigraffle.rb
+++ b/recipes/omnigraffle.rb
@@ -1,5 +1,5 @@
 include_recipe "applications::homebrewcask"
-applications_cask "omni-graffle"
+applications_cask "omni-graffle-pro"
 
 gtemplate = "#{node['etc']['passwd'][node['current_user']]['dir']}/Library/Application Support/OmniGraffle/Templates/Konigi-UX-Template.gtemplate"
 unless File.exists?(gtemplate)

--- a/recipes/rubymine.rb
+++ b/recipes/rubymine.rb
@@ -1,5 +1,2 @@
-dmg_package "RubyMine" do
-  source "http://download.jetbrains.com/ruby/RubyMine-5.4.3.dmg"
-  action :install
-  owner node['current_user']
-end
+include_recipe "applications::homebrewcask"
+applications_cask "rubymine"

--- a/recipes/skype.rb
+++ b/recipes/skype.rb
@@ -1,5 +1,2 @@
-dmg_package "Skype" do
-    source "http://www.skype.com/go/getskype-macosx.dmg"
-    action :install
-    only_if { platform?('mac_os_x') }
-end
+include_recipe "applications::homebrewcask"
+applications_cask "skype"

--- a/recipes/synergy.rb
+++ b/recipes/synergy.rb
@@ -1,8 +1,2 @@
-dmg_package "Synergy" do
-  source "http://synergy.googlecode.com/files/synergy-1.4.10-MacOSX108-x86_64.dmg"
-  action :install
-  owner node['current_user']
-end
-
-
-
+include_recipe "applications::homebrewcask"
+applications_cask "synergy"

--- a/recipes/things.rb
+++ b/recipes/things.rb
@@ -1,3 +1,2 @@
-applications_package "Things" do
-  source  "http://culturedcode.com/things/download/"
-end
+include_recipe "applications::homebrewcask"
+applications_cask "things"

--- a/recipes/tower.rb
+++ b/recipes/tower.rb
@@ -1,3 +1,2 @@
-applications_package "Tower" do
-  source  "http://www.git-tower.com/download"
-end
+include_recipe "applications::homebrewcask"
+applications_cask "tower"

--- a/recipes/tunnelblick.rb
+++ b/recipes/tunnelblick.rb
@@ -1,3 +1,2 @@
-applications_package "Tunnelblick" do
-  source  "http://tunnelblick.googlecode.com/files/Tunnelblick_3.3beta21b_Unsigned.zip"
-end
+include_recipe "applications::homebrewcask"
+applications_cask "tunnelblick"

--- a/recipes/viscosity.rb
+++ b/recipes/viscosity.rb
@@ -1,5 +1,2 @@
-dmg_package "Viscosity" do
-  source "http://www.sparklabs.com/downloads/Viscosity.dmg"
-  action :install
-  owner node['current_user']
-end
+include_recipe "applications::homebrewcask"
+applications_cask "viscosity"

--- a/recipes/wireshark.rb
+++ b/recipes/wireshark.rb
@@ -1,9 +1,4 @@
 include_recipe "applications::xquartz"
 
-dmg_package "Wireshark 1.10.0 Intel 64" do
-  source "http://wiresharkdownloads.riverbed.com/wireshark/osx/Wireshark%201.10.0%20Intel%2064.dmg"
-  volumes_dir "Wireshark"
-  action :install
-  type "pkg"
-  package_id "org.wireshark.Wireshark.pkg"
-end
+include_recipe "applications::homebrewcask"
+applications_cask "wireshark"

--- a/recipes/xquartz.rb
+++ b/recipes/xquartz.rb
@@ -1,8 +1,2 @@
-dmg_package "XQuartz" do
-  source "http://xquartz.macosforge.org/downloads/SL/XQuartz-2.7.4.dmg"
-  action :install
-  volumes_dir "XQuartz-2.7.4"
-  type "pkg"
-  owner node['current_user']
-  package_id "org.macosforge.xquartz.pkg"
-end
+include_recipe "applications::homebrewcask"
+applications_cask "x-quartz"


### PR DESCRIPTION
Changed to follow brew-cask:
- Chicken
- Crashplan
- Cyberduck
- DiffMerge
- Flash
- Flux
- Handbrake
- Hostbuddy
- ImageAlpha
- ImageOptim
- KeyboardCleanTool
- LastPass
- Mou
- RubyMine
- Skype
- Synergy
- Things
- Tower
- Tunnelblick
- Viscosity
- Wireshark
- Xquartz

Updated:
- Crashplan 3.5.3
- Cyberduck 4.3.1
- DiffMerge 4.1.0
- ImageAlpha 1.3.5
- OmniGraffle Pro (We had a change in tracking OmniGraffle by version)
- Wireshark 1.10.2
