### PR TITLE
Add iTerm2

### DIFF
--- a/recipes/iterm2.rb
+++ b/recipes/iterm2.rb
@@ -1,0 +1,2 @@
+include_recipe "applications::homebrewcask"
+applications_cask "iterm2"


### PR DESCRIPTION
iTerm2 is a replacement for Terminal and the successor to iTerm. It
works on Macs with OS 10.5 (Leopard) or newer. Its focus is on
performance, internationalization, and supporting innovative features
that make your life better.
