### PR TITLE
Add tig

### DIFF
--- a/recipes/tig.rb
+++ b/recipes/tig.rb
@@ -1,0 +1,5 @@
+include_recipe "applications::default"
+
+package 'tig' do
+  action [:install, :upgrade]
+end


### PR DESCRIPTION
Tig is an ncurses-based text-mode interface for git. It functions mainly as a Git repository browser, but can also assist in staging changes for commit at chunk level and act as a pager for output from various Git commands.
