### PR TITLE
Add recipe 'sublime_text_3_without_node_js'

### DIFF
--- a/recipes/sublime_text_3_without_node_js.rb
+++ b/recipes/sublime_text_3_without_node_js.rb
@@ -1,0 +1,37 @@
+include_recipe "homebrewalt::default"
+
+homebrewalt_cask "sublime-text3"
+
+sublime_path = "#{node['etc']['passwd'][node['current_user']]['dir']}/Library/Application Support/Sublime Text 3"
+sublime_package_path = "#{sublime_path}/Packages"
+sublime_user_path = "#{sublime_package_path}/User"
+sublime_installed_packages_path = "#{sublime_path}/Installed Packages"
+
+[sublime_path, sublime_package_path, sublime_user_path, sublime_installed_packages_path].each do |dir|
+    directory dir do
+        owner node['current_user']
+        recursive true
+    end
+end
+
+remote_file "#{sublime_installed_packages_path}/Package Control.sublime-package" do
+    source 'http://sublime.wbond.net/Package%20Control.sublime-package'
+    owner node['current_user']
+    action :create_if_missing
+end
+
+node["sublime_text_packages"].each do |package|
+    applications_sublime_package package["name"] do
+        source package["source"]
+        branch package["branch"]
+        destination File.join(sublime_package_path)
+        owner node['current_user']
+    end
+end
+
+require 'json'
+file File.expand_path("Preferences.sublime-settings", File.join(sublime_user_path)) do
+    content JSON.generate(node['sublime_text']['preferences'], {:indent => "  ", :object_nl => "\n"})
+    owner node['current_user']
+    action :create_if_missing
+end


### PR DESCRIPTION
This is identical to the 'sublime_text_3' recipe but does not include the 'jshint' and 'csslint' node js packages which means nodejs::default is not required to install Sublime.

The reason for this is because there is no need for Sublime to depend on node js. I also prefer to use nvm to manage node versions rather than install node from homebrew.

[Link to Travis CI Build](https://travis-ci.org/andystanton/chef-applications/builds/19217791)
