### PR TITLE
Quote mysql password

### DIFF
--- a/recipes/mysql.rb
+++ b/recipes/mysql.rb
@@ -69,7 +69,7 @@ ruby_block "Checking that mysql is running" do
 end
 
 execute "set the root password to the default" do
-    command "mysqladmin -uroot password #{PASSWORD}"
-    not_if "mysql -uroot -p#{PASSWORD} -e 'show databases'"
+    command "mysqladmin -uroot password '#{PASSWORD}'"
+    not_if "mysql -uroot #{PASSWORD.empty? ? "" : "-p '#{PASSWORD}'"} -e 'show databases'"
 end
 


### PR DESCRIPTION
Corrects for passwords that are either blank (no password) or contain symbols.
