### PR TITLE
Add install recipe for forego

### DIFF
--- a/recipes/forego.rb
+++ b/recipes/forego.rb
@@ -1,0 +1,14 @@
+# Forego: a foreman alternative in Go
+# https://github.com/bukowskis/homebrew-bukowskis/blob/master/forego.rb
+
+case node["platform_family"]
+    when 'mac_os_x'
+        include_recipe "homebrewalt::default"
+        homebrewalt_tap "bukowskis/bukowskis"
+
+        package "forego" do
+          action [:install, :upgrade]
+        end
+    when 'debian'
+        Chef::Log.debug("This recipe is OSX only")
+end


### PR DESCRIPTION
I have concerns about homebrewalt. This cookbook specifically seems of split mind as to whether it needs homebrew or homebrewalt. Some recipes use homebrew_tap lwrp, which doesn't work with homebrewalt.
