### PR TITLE
Fix typo in mysql command

### DIFF
--- a/recipes/mysql.rb
+++ b/recipes/mysql.rb
@@ -70,6 +70,6 @@ end
 
 execute "set the root password to the default" do
     command "mysqladmin -uroot password '#{PASSWORD}'"
-    not_if "mysql -uroot #{PASSWORD.empty? ? "" : "-p '#{PASSWORD}'"} -e 'show databases'"
+    not_if "mysql -uroot #{PASSWORD.empty? ? "" : "-p'#{PASSWORD}'"} -e 'show databases'"
 end
 


### PR DESCRIPTION
There should be no space between -p and the password. Otherwise, the not_if command always fails.
