### PR TITLE
Add gems recipe

### DIFF
--- a/attributes/gems.rb
+++ b/attributes/gems.rb
@@ -1,0 +1,1 @@
+default['gems'] = []

--- a/recipes/gems.rb
+++ b/recipes/gems.rb
@@ -1,0 +1,3 @@
+node['gems'].each do |gem|
+  gem_package gem
+end

--- a/recipes/sass.rb
+++ b/recipes/sass.rb
@@ -1,1 +1,0 @@
-gem_package "sass"


### PR DESCRIPTION
I swapped out the sass recipe with one that can install a defined list of gems for more flexibility.

It works, but I was wondering if I could ask your help: where, by default, does Chef's `gem_package` install your gems on OS X?
