### PR TITLE
Fix bash to use homebrew version

### DIFF
--- a/recipes/bash.rb
+++ b/recipes/bash.rb
@@ -1,7 +1,14 @@
+include_recipe "homebrewalt::default"
+
 case node["platform_family"]
     when 'mac_os_x'
+        homebrewalt_tap "homebrew/dupes"
+        package "bash" do
+          action [:install, :upgrade]
+        end
         execute "set the root user shell to bash" do
-          command "dscl . -create /Users/root UserShell /bin/bash"
+          command "sudo bash -c 'echo /usr/local/bin/bash >> /etc/shells'"
+          command "sudo chsh -s /usr/local/bin/bash #{node['current_user']}"
         end
 
         link "/root" do


### PR DESCRIPTION
I'm not sure if you'll want this one (though it's definitely the way I went with it when I just provisioned my machine), but it switches the bash installation method to use homebrew's bash and switch the user's shell to use it.
