### PR TITLE
Add recipe to use and enable homebrew's bash

### DIFF
--- a/recipes/homebrew-bash.rb
+++ b/recipes/homebrew-bash.rb
@@ -1,0 +1,19 @@
+include_recipe "homebrewalt::default"
+
+case node["platform_family"]
+    when 'mac_os_x'
+        homebrewalt_tap "homebrew/dupes"
+        package "bash" do
+          action [:install, :upgrade]
+        end
+        execute "set the root user shell to bash" do
+          command "sudo bash -c 'echo /usr/local/bin/bash >> /etc/shells'"
+          command "sudo chsh -s /usr/local/bin/bash #{node['current_user']}"
+        end
+
+        link "/root" do
+            to "/var/root"
+        end
+    when 'debian'
+        Chef::Log.debug("This recipe is OSX only")
+end


### PR DESCRIPTION
Instead of modifying bash.rb, this adds a new recipe to add and configure homebrew's bash version.

Thanks for merging my other PRs (and cleaning up the ini stuff). I was just wondering why composer was deleted in the process?
