### PR TITLE
WIP Fix gem installation

### DIFF
--- a/recipes/gems.rb
+++ b/recipes/gems.rb
@@ -1,5 +1,8 @@
+#gem_install_dir = `gem env gemdir | tr -d "\n"`
+gem_install_dir = '/Library/Ruby/Gems/2.0.0'
 node['gems'].each do |gem|
   gem_package gem do
-    gem_binary '/usr/bin/ruby'
+    gem_binary("/usr/bin/gem")
+    options("--install-dir '#{gem_install_dir}' --bindir '/usr/bin'")
   end
 end


### PR DESCRIPTION
I am opening this PR for discussion only as it is not ready to merge.

:warning: This fixes gem installation for `kitchenplan` by assuming commands and file locations. It is poorly implemented at the moment due to hard coding of the gem installation path. If resolved it should close [kitchenplan issue #109](https://github.com/kitchenplan/kitchenplan/issues/109).